### PR TITLE
Prevented plugin from attempting to squelch Bob in Battlegrounds games

### DIFF
--- a/Autosquelch/AutosquelchPlugin.cs
+++ b/Autosquelch/AutosquelchPlugin.cs
@@ -89,7 +89,8 @@ To temporarily turn off the autosquelch, press Ctrl+Alt+D";
             get
             {
                 return Hearthstone_Deck_Tracker.API.Core.Game.CurrentGameMode != GameMode.Practice
-                        && Hearthstone_Deck_Tracker.API.Core.Game.CurrentGameMode != GameMode.None;
+                        && Hearthstone_Deck_Tracker.API.Core.Game.CurrentGameMode != GameMode.None 
+                        && Hearthstone_Deck_Tracker.API.Core.Game.CurrentGameMode != GameMode.Battlegrounds;
             }
         }
 


### PR DESCRIPTION
At the start of Battlegrounds games, the plugin keeps trying to squelch Bob as if he were a normal player.